### PR TITLE
fix: Install Terraform before running terraform commands

### DIFF
--- a/.github/workflows/provision-s3-static-site.yaml
+++ b/.github/workflows/provision-s3-static-site.yaml
@@ -20,6 +20,9 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1  # substitua pela região desejada
 
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v2
+
       - name: Extract Bucket Name from Issue
         run: |
           export BUCKET_NAME=$(echo "${{ github.event.issue.title }}")


### PR DESCRIPTION
## Problema
O workflow estava falhando ao executar comandos do Terraform com o seguinte erro:
```
terraform: command not found
Error: Process completed with exit code 127.
```

Isso ocorria porque o Terraform não estava instalado no runner do GitHub Actions antes de tentar executar os comandos `terraform init` e `terraform apply`.

## O que foi feito
Adicionei um step para instalar o Terraform usando a action oficial `hashicorp/setup-terraform@v2` antes dos comandos que dependem dele.

- Adicionado step "Install Terraform" usando `hashicorp/setup-terraform@v2` na ordem de execução correta

## Demonstração
A seguir segue o link de dois Workflows que demonstram o comportamento antes e depois dessa alteração:

- [Workflow antes da alteração](https://github.com/ViniciusCassemira/infrastructure/actions/runs/20107241505)
- [Workflow depois da alteração](https://github.com/ViniciusCassemira/infrastructure/actions/runs/20107462217)
